### PR TITLE
Align test coverage and README with the sibling OWID implementations

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,26 @@
 
 # Open Web Id (OWID) JavaScript
 
-Open Web Id (OWID) - a open source cryptographically secure shared web identifier 
-schema implemented in JavaScript
+## Overview
 
-Read the [OWID](https://github.com/SWAN-community/owid) project to learn more about
-the concepts before looking into this implementation.
+Open Web Id (OWID) is an open source cryptographically secure shared web
+identifier schema. This repository implements OWID in JavaScript.
+
+Read the [OWID](https://github.com/SWAN-community/owid) project to learn more
+about the concepts before looking into this implementation.
+
+## Scope of this implementation
+
+This library is verify only and is intended for use in the browser. It parses
+OWIDs that were created elsewhere and verifies their signatures. It cannot
+create or sign OWIDs. Creation and signing are implemented in the server side
+libraries [owid-go](https://github.com/SWAN-community/owid-go) and
+[owid-dotnet](https://github.com/SWAN-community/owid-dotnet).
+
+When the browser provides `crypto.subtle` the library fetches the creator's
+public key from their well known end point and verifies the ECDSA signature
+locally. When `crypto.subtle` is not available it falls back to the creator's
+remote verify end point.
 
 ## Usage
 
@@ -22,22 +37,23 @@ To use OWID-js:
     var o = new owid("[owid base 64 string]");
     o.verify().then(valid  => console.log(valid));
     ```
+
 ## Interface
 
-OWID-js library is used to construct owid objects and verify against other 
+OWID-js library is used to construct owid objects and verify against other
 instances of OWID or base 64 encoded strings representing OWID trees.
 
 ### Constructor
 
-Create a new instance of OWID without any data. The instance can still be used to 
-verify other OWIDs.
+Create a new instance of OWID without any data. The instance can still be used
+to verify other OWIDs.
 ```js
 var o = new owid();
 ```
 
-Create a new instance of OWID using a encrypted OWID.
+Create a new instance of OWID using a base 64 encoded OWID.
 ```js
-var o = new owid("<encrypted data>");
+var o = new owid("<base 64 encoded OWID>");
 ```
 
 ### Methods
@@ -47,17 +63,21 @@ Methods available to call on an instance of OWID.
 |Method|Params|Return Type|Description|
 |-|-|-|-|
 |dateAsJavaScriptDate|n/a|Date|Returns the OWID creation date as a JavaScript Date object.|
+|parse|base 64 string (optional)|Object|Parses a base 64 encoded OWID into an OWID tree. Uses the instance's own data when no parameter is provided.|
 |payloadAsPrintable|n/a|string|Returns the payload in hexadecimal.|
 |payloadAsString|n/a|string|Returns the payload as a string.|
 |payloadAsBase64|n/a|string|Returns the payload as a base 64 string.|
+|stop|owid, domain, return url|n/a|Posts the domain and return URL to the `/stop` end point and redirects the browser to the URL contained in the response.|
 |verify|owid\|owids[]|Promise(bool)|The verify method determines if the OWID instance is valid. It also takes an array of other OWID instances or strings that can be turned into OWIDs to verify the current OWID against.|
 
 ### Fields
 
 |Field|Type|Description|
 |-|-|-|
+|data|string|Returns the base 64 string the instance was created from.|
 |date|number|Returns the date and time the OWID was created in UTC as minutes since `2020-01-01 00:00`|
 |domain|string|Returns the creator of the OWID.|
+|owid|Object|Returns the parsed OWID tree.|
 |signature|Uint8Array|Returns the signature as byte array.|
 
 ## Examples
@@ -115,31 +135,57 @@ o.verify([other1, other2, other3])
     .catch(error => console.log(error));
 ```
 
-## Tests
+## Testing
 
-Tests are performed using Jest.
+Tests are performed using Jest. The fetch calls made by the library are
+mocked with jest-fetch-mock. The tests in `owid.test.js` cover parsing and
+the remote verify end point. The tests in `owid.crypto.test.js` cover local
+ECDSA signature verification using the web crypto implementation provided by
+Node.
 
 ### Pre-requisites
 
-* Nodejs version 15.x or above
-* Yarn
+* Node.js version 15 or above. The tests are routinely run with Node.js 24.
+* Yarn or npm. The repository includes a `yarn.lock` file, so Yarn is
+  preferred.
 
 ### Steps
 
-Install yarn,
+Install yarn if it is not already available.
 
 ```bash
 npm install --global yarn
 ```
 
-Install Jest.
+Install the dependencies.
 
 ```bash
 yarn install
 ```
 
-Run tests.
+Run the tests.
 
 ```bash
 yarn test
 ```
+
+Alternatively use npm.
+
+```bash
+npm install
+npm test
+```
+
+## Related repositories
+
+* [owid](https://github.com/SWAN-community/owid) defines the OWID
+  specification and concepts.
+* [owid-go](https://github.com/SWAN-community/owid-go) is the Go
+  implementation. It creates, signs and verifies OWIDs server side.
+* [owid-dotnet](https://github.com/SWAN-community/owid-dotnet) is the .NET
+  implementation. It creates, signs and verifies OWIDs server side.
+
+## License
+
+This project is licensed under the Apache License, Version 2.0. See the
+[LICENSE](LICENSE) file for details.

--- a/README.md
+++ b/README.md
@@ -141,7 +141,8 @@ Tests are performed using Jest. The fetch calls made by the library are
 mocked with jest-fetch-mock. The tests in `owid.test.js` cover parsing and
 the remote verify end point. The tests in `owid.crypto.test.js` cover local
 ECDSA signature verification using the web crypto implementation provided by
-Node.
+Node. The tests in `owid.interop.test.js` verify fixtures signed by the
+Rust, Go and .NET implementations to prove cross-language compatibility.
 
 ### Pre-requisites
 
@@ -183,6 +184,8 @@ npm test
 * [owid-go](https://github.com/SWAN-community/owid-go) is the Go
   implementation. It creates, signs and verifies OWIDs server side.
 * [owid-dotnet](https://github.com/SWAN-community/owid-dotnet) is the .NET
+  implementation. It creates, signs and verifies OWIDs server side.
+* [owid-rust](https://github.com/SWAN-community/owid-rust) is the Rust
   implementation. It creates, signs and verifies OWIDs server side.
 
 ## License

--- a/owid.crypto.test.js
+++ b/owid.crypto.test.js
@@ -1,0 +1,228 @@
+/* ****************************************************************************
+ * Copyright 2021 51 Degrees Mobile Experts Limited (51degrees.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ * ***************************************************************************/
+
+// These tests exercise the local public key verification path. When
+// crypto.subtle is available the library fetches the creator's public key
+// from the well known end point and verifies the ECDSA signature locally
+// instead of calling the remote verify end point. Node 24 provides a web
+// crypto implementation, so it is exposed here in the same way a browser
+// would. The OWIDs used are test data constructed and signed with node's
+// crypto module inside this file, the library itself never signs anything.
+
+const owid = require('./v1');
+const nodeCrypto = require('crypto');
+
+Object.defineProperty(global.self, 'crypto', {
+    value: {
+        subtle: nodeCrypto.webcrypto.subtle
+    }
+});
+
+// Key pair used to sign the test OWIDs.
+const creatorKeyPair = nodeCrypto.generateKeyPairSync('ec', {
+    namedCurve: 'prime256v1'
+});
+
+// A second key pair that has not signed anything, used to prove that
+// verification fails when the creator returns the wrong public key.
+const otherKeyPair = nodeCrypto.generateKeyPairSync('ec', {
+    namedCurve: 'prime256v1'
+});
+
+// 2021-04-06 12:59 UTC expressed as minutes since 2020-01-01 00:00 UTC.
+const testDateInMinutes = 664619;
+
+const creatorDomain = "creator.swan-demo.uk";
+const wrongKeyDomain = "wrong-key.swan-demo.uk";
+
+/**
+ * Builds the unsigned portion of a version 3 OWID as a byte array in the
+ * same form the library serializes for verification.
+ * @param {string} domain - the creator domain.
+ * @param {number} dateInMinutes - minutes since the OWID base date.
+ * @param {Buffer} payload - the payload bytes.
+ * @returns {Buffer} the unsigned OWID bytes.
+ */
+function buildUnsignedOWID(domain, dateInMinutes, payload) {
+    var date = Buffer.alloc(4);
+    date.writeUInt32LE(dateInMinutes);
+    var length = Buffer.alloc(4);
+    length.writeUInt32LE(payload.length);
+    return Buffer.concat([
+        Buffer.from([3]),
+        Buffer.from(domain, 'ascii'),
+        Buffer.from([0]),
+        date,
+        length,
+        payload
+    ]);
+}
+
+/**
+ * Signs the unsigned OWID bytes, together with any additional data, and
+ * returns the complete OWID as a base 64 string. The signature uses the raw
+ * 64 byte r and s form that the OWID format requires.
+ * @param {Buffer} unsigned - the unsigned OWID bytes.
+ * @param {Object} privateKey - the signing key.
+ * @param {Buffer} [extra] - additional data covered by the signature, used
+ * when one OWID signs another.
+ * @returns {string} the complete OWID as base 64.
+ */
+function signOWID(unsigned, privateKey, extra) {
+    var message = extra ?
+        Buffer.concat([unsigned, extra]) :
+        unsigned;
+    var signature = nodeCrypto.sign('sha256', message, {
+        key: privateKey,
+        dsaEncoding: 'ieee-p1363'
+    });
+    return Buffer.concat([unsigned, signature]).toString('base64');
+}
+
+/**
+ * Returns the base 64 string with a single byte changed at the given offset
+ * of the decoded byte array.
+ * @param {string} encoded - the OWID as base 64.
+ * @param {number} offset - byte offset to corrupt, negative counts from the
+ * end.
+ * @returns {string} the corrupted OWID as base 64.
+ */
+function corruptByte(encoded, offset) {
+    var bytes = Buffer.from(encoded, 'base64');
+    var index = offset < 0 ? bytes.length + offset : offset;
+    bytes[index] = bytes[index] ^ 0xFF;
+    return bytes.toString('base64');
+}
+
+beforeEach(() => {
+    fetchMock.resetMocks();
+
+    fetchMock.mockResponse(req => {
+        var urlString = req.url;
+        if (urlString.startsWith("//")) {
+            urlString = "http:" + urlString;
+        }
+        var url = new URL(urlString);
+
+        if (url.pathname.endsWith("/creator")) {
+            var keyPair = url.hostname == wrongKeyDomain ?
+                otherKeyPair :
+                creatorKeyPair;
+            return Promise.resolve(JSON.stringify({
+                publicKeySPKI: keyPair.publicKey.export({
+                    type: 'spki',
+                    format: 'pem'
+                })
+            }));
+        }
+        return Promise.resolve({
+            status: 404,
+            body: "Not Found"
+        });
+    });
+});
+
+test('crypto verify valid OWID passes', () => {
+    var unsigned = buildUnsignedOWID(
+        creatorDomain, testDateInMinutes, Buffer.from("example"));
+    var o = new owid(signOWID(unsigned, creatorKeyPair.privateKey));
+
+    return o.verify().then(valid => {
+        expect(valid).toBe(true);
+        // The library must have used the public key path, so the only
+        // request is to the creator end point.
+        expect(fetch.mock.calls.length).toBe(1);
+        expect(fetch.mock.calls[0][0]).toBe(
+            "//" + creatorDomain + "/owid/api/v1/creator");
+    });
+});
+
+test('crypto verify tampered signature fails', () => {
+    var unsigned = buildUnsignedOWID(
+        creatorDomain, testDateInMinutes, Buffer.from("example"));
+    var valid = signOWID(unsigned, creatorKeyPair.privateKey);
+    // Corrupt the last byte, which is always within the 64 byte signature.
+    var o = new owid(corruptByte(valid, -1));
+
+    return o.verify().then(valid => {
+        expect(valid).toBe(false);
+    });
+});
+
+test('crypto verify tampered payload fails', () => {
+    var unsigned = buildUnsignedOWID(
+        creatorDomain, testDateInMinutes, Buffer.from("example"));
+    var valid = signOWID(unsigned, creatorKeyPair.privateKey);
+    // Corrupt the last payload byte, which is the last byte before the 64
+    // byte signature.
+    var o = new owid(corruptByte(valid, -65));
+
+    return o.verify().then(valid => {
+        expect(valid).toBe(false);
+    });
+});
+
+test('crypto verify wrong public key fails', () => {
+    var unsigned = buildUnsignedOWID(
+        wrongKeyDomain, testDateInMinutes, Buffer.from("example"));
+    // The OWID is signed correctly but the mocked creator end point for
+    // this domain returns a different public key.
+    var o = new owid(signOWID(unsigned, creatorKeyPair.privateKey));
+
+    return o.verify().then(valid => {
+        expect(valid).toBe(false);
+    });
+});
+
+test('crypto verify party OWID signed with creator OWID passes', () => {
+    var creatorUnsigned = buildUnsignedOWID(
+        creatorDomain, testDateInMinutes, Buffer.from("example"));
+    var creator = new owid(
+        signOWID(creatorUnsigned, creatorKeyPair.privateKey));
+
+    // The party signature covers the party bytes followed by the complete
+    // creator OWID, matching how SWAN parties sign a transaction.
+    var partyUnsigned = buildUnsignedOWID(
+        creatorDomain, testDateInMinutes, Buffer.from([1, 3]));
+    var party = new owid(signOWID(
+        partyUnsigned,
+        creatorKeyPair.privateKey,
+        Buffer.from(creator.data, 'base64')));
+
+    return party.verify(creator).then(valid => {
+        expect(valid).toBe(true);
+    });
+});
+
+test('crypto verify party OWID with wrong creator OWID fails', () => {
+    var creatorUnsigned = buildUnsignedOWID(
+        creatorDomain, testDateInMinutes, Buffer.from("example"));
+    var creator = new owid(
+        signOWID(creatorUnsigned, creatorKeyPair.privateKey));
+
+    // The party signature covers different additional data to the creator
+    // OWID passed to verify, so verification must fail.
+    var partyUnsigned = buildUnsignedOWID(
+        creatorDomain, testDateInMinutes, Buffer.from([1, 3]));
+    var party = new owid(signOWID(
+        partyUnsigned,
+        creatorKeyPair.privateKey,
+        Buffer.from("different data")));
+
+    return party.verify(creator).then(valid => {
+        expect(valid).toBe(false);
+    });
+});

--- a/owid.interop.test.js
+++ b/owid.interop.test.js
@@ -1,0 +1,230 @@
+/* ****************************************************************************
+ * Copyright 2021 51 Degrees Mobile Experts Limited (51degrees.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ * ***************************************************************************/
+
+// These tests prove cross language compatibility. The OWID fixtures below
+// were created and signed by the Rust, Go and .NET implementations on
+// 2026-06-12 using throwaway P-256 keys generated only for the fixtures. At
+// generation time the full matrix was verified, all four implementations
+// verified all of the fixtures and rejected tampered copies. As in
+// owid.crypto.test.js the tests exercise the local public key verification
+// path. Node 24 provides a web crypto implementation, so it is exposed here
+// in the same way a browser would, and the creator end point is mocked to
+// return the public key matching each fixture's signing key.
+
+const owid = require('./v1');
+const nodeCrypto = require('crypto');
+
+Object.defineProperty(global.self, 'crypto', {
+    value: {
+        subtle: nodeCrypto.webcrypto.subtle
+    }
+});
+
+// The expected payload of the utf8 fixtures once decoded as UTF-8.
+const utf8PayloadText = "Zürich ❤ OWID £€";
+
+// One fixture set per implementation. The simple case carries the ASCII
+// payload "example". The utf8 case carries the UTF-8 payload above. The
+// chain case is a party OWID with payload "party" whose signature also
+// covers the root OWID in chainRoot, both signed with the same key.
+const fixtures = [
+    {
+        language: "rust",
+        domain: "rust.swan-demo.uk",
+        publicKeySPKI:
+            "-----BEGIN PUBLIC KEY-----\n" +
+            "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEQcDroVnBAGAvy1SyUz4MyFxP16ki\n" +
+            "aPLulPz92rmbDbFKB6p0xl3iatZQ0uADa+F9cZeemLKtlfPaaue/KvNQOw==\n" +
+            "-----END PUBLIC KEY-----\n",
+        simple:
+            "A3J1c3Quc3dhbi1kZW1vLnVrAD69MwAHAAAAZXhhbXBsZQtzvD+xirWingyf" +
+            "DxbykxurSxK4XdixdGR5lR0xnHmv2IFSsVCub2Jd1jRg/vQJ8XnXuNljRp/E" +
+            "rjSOMMQo5CI=",
+        utf8:
+            "A3J1c3Quc3dhbi1kZW1vLnVrAD69MwAWAAAAWsO8cmljaCDinaQgT1dJRCDC" +
+            "o+KCrDHenDds+W587AzXpBb94gmLOloeBJTlHnjCkez4Dz2yAPtjcoQ6M/ZU" +
+            "WDIobtJHE5n9a81pTsn/Kvi74Azzx4s=",
+        chainParty:
+            "A3J1c3Quc3dhbi1kZW1vLnVrAD69MwAFAAAAcGFydHmJ7qaxWgIZUHmGOQb2" +
+            "xC+RuZNwrkMmo1SA9/MfI4SoEpRYdnteXAKUQXxTOK3lmQ3Qz3UwBB6gBb3Q" +
+            "8hi1Wx0R",
+        chainRoot:
+            "A3J1c3Quc3dhbi1kZW1vLnVrAD69MwAEAAAAcm9vdFd0+QLaBLGPyBrQO+VN" +
+            "unBIQZzw8/lhEiDOKTx36Dc93A0n0fzPDMt/C+BdWMqhnL4nVvyurb3IHR7D" +
+            "UAmgmO0="
+    },
+    {
+        language: "go",
+        domain: "go.swan-demo.uk",
+        publicKeySPKI:
+            "-----BEGIN PUBLIC KEY-----\n" +
+            "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEeO51FrQ8AmCFjLnePUH1qQ4GWGxj\n" +
+            "1aL5ux6vNJFSRnGTVc5YC8kEwqfOaMEjVWqt4Gbq4+lEnIAgTl76YAGpcA==\n" +
+            "-----END PUBLIC KEY-----\n",
+        simple:
+            "A2dvLnN3YW4tZGVtby51awA/vTMABwAAAGV4YW1wbGVPIQZ/uhIjVxrROjMD" +
+            "fcAkRk8U4fYacm0Ck4aOxoRDJPK/QrKavqZqCf7cCKbNuJ0aA7GhVeuy4oje" +
+            "SzNX56Qn",
+        utf8:
+            "A2dvLnN3YW4tZGVtby51awA/vTMAFgAAAFrDvHJpY2gg4p2kIE9XSUQgwqPi" +
+            "gqzxY+4QgUGt84xC9HxHmHXDt+wcB0Y9a6E+Txm2F147Qacbp0CtrF8x7QCW" +
+            "ZfkcKCKNGSM8hYZEfYjJtViG+tA+",
+        chainParty:
+            "A2dvLnN3YW4tZGVtby51awA/vTMABQAAAHBhcnR5l7NyNmFw2lxqc4DKJWoq" +
+            "0UVd5ujGV/+fvVxqYTRlwCFxaSuwvnhLQQHjX5spxWb4O08IeuiuGCat1WFB" +
+            "/Wqlyw==",
+        chainRoot:
+            "A2dvLnN3YW4tZGVtby51awA/vTMABAAAAHJvb3R/bEqzG8gAy9yTF1UMEtOl" +
+            "YXBBmn3a20jxXq5NmxIC8iuZvduOXKMf+K8VoAapkWwfpoDKQHS09IhljasZ" +
+            "qC0k"
+    },
+    {
+        language: "dotnet",
+        domain: "dotnet.swan-demo.uk",
+        publicKeySPKI:
+            "-----BEGIN PUBLIC KEY-----\n" +
+            "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEec6dTi0JOYGP78lw7/zAjp3r73fZ\n" +
+            "A7zSi4Ov90sVxgmqZ4cI1sbj7AbsnBhqJDe5Hu14gDBjZWErL7KpkjEl0A==\n" +
+            "-----END PUBLIC KEY-----",
+        simple:
+            "A2RvdG5ldC5zd2FuLWRlbW8udWsAPb0zAAcAAABleGFtcGxlVegwXS00P/DU" +
+            "2FJbLjof8qc/BwrffhbKJkV42pqFd7nUD+KR/DxxRSfLlm77/kAyR/dLOcwE" +
+            "etjN1z9UWzyh0w==",
+        utf8:
+            "A2RvdG5ldC5zd2FuLWRlbW8udWsAPb0zABYAAABaw7xyaWNoIOKdpCBPV0lE" +
+            "IMKj4oKsVuaeaDUej0sF+cHfYj/icDBmlBLOviC6ZE28am8EtY+IGuesFcg2" +
+            "rKMybcsAxMmnrDtF2xsk1cJvHgoIYpSJJQ==",
+        chainParty:
+            "A2RvdG5ldC5zd2FuLWRlbW8udWsAPb0zAAUAAABwYXJ0eXtD6H4R7GbvRyFU" +
+            "+bCKgjMAZFFm8KHln80XPwQOBb/Ub9EZfE4Ml3ueRkKX51+MD98RFgTSmjbq" +
+            "rAnzFkLlilA=",
+        chainRoot:
+            "A2RvdG5ldC5zd2FuLWRlbW8udWsAPb0zAAQAAAByb290fErj2LccPYCduWUW" +
+            "8vY2aBjrecDfnTpVpv3+SESJMFW5pcuPKEQik2rC0fWEoB5Vr6e0k5inrhUG" +
+            "iF2c2Y2YDw=="
+    }
+];
+
+// Public key PEM keyed on the creator domain so the mocked creator end
+// point can return the right key for each implementation.
+const publicKeys = {};
+fixtures.forEach(f => {
+    publicKeys[f.domain] = f.publicKeySPKI;
+});
+
+/**
+ * Returns the base 64 string with a single byte changed at the given offset
+ * of the decoded byte array.
+ * @param {string} encoded - the OWID as base 64.
+ * @param {number} offset - byte offset to corrupt, negative counts from the
+ * end.
+ * @returns {string} the corrupted OWID as base 64.
+ */
+function corruptByte(encoded, offset) {
+    var bytes = Buffer.from(encoded, 'base64');
+    var index = offset < 0 ? bytes.length + offset : offset;
+    bytes[index] = bytes[index] ^ 0xFF;
+    return bytes.toString('base64');
+}
+
+beforeEach(() => {
+    fetchMock.resetMocks();
+
+    fetchMock.mockResponse(req => {
+        var urlString = req.url;
+        if (urlString.startsWith("//")) {
+            urlString = "http:" + urlString;
+        }
+        var url = new URL(urlString);
+
+        if (url.pathname.endsWith("/creator") && publicKeys[url.hostname]) {
+            return Promise.resolve(JSON.stringify({
+                publicKeySPKI: publicKeys[url.hostname]
+            }));
+        }
+        return Promise.resolve({
+            status: 404,
+            body: "Not Found"
+        });
+    });
+});
+
+fixtures.forEach(f => {
+
+    test('interop verify ' + f.language + ' simple OWID passes', () => {
+        var o = new owid(f.simple);
+
+        return o.verify().then(valid => {
+            expect(valid).toBe(true);
+            // The library must have used the public key path, so the only
+            // request is to the creator end point.
+            expect(fetch.mock.calls.length).toBe(1);
+            expect(fetch.mock.calls[0][0]).toBe(
+                "//" + f.domain + "/owid/api/v1/creator");
+        });
+    });
+
+    test('interop verify ' + f.language + ' utf8 OWID passes', () => {
+        var o = new owid(f.utf8);
+
+        return o.verify().then(valid => {
+            expect(valid).toBe(true);
+        });
+    });
+
+    test('interop ' + f.language + ' utf8 payload decodes to the ' +
+        'expected text', () => {
+        var o = new owid(f.utf8);
+
+        // The parsed tree exposes the payload as a byte array. Decode the
+        // bytes as UTF-8 rather than using payloadAsString, which maps each
+        // byte to a character and would mangle multi byte sequences.
+        var text = Buffer.from(o.owid.payload).toString('utf8');
+        expect(text).toBe(utf8PayloadText);
+    });
+
+    test('interop verify ' + f.language + ' party OWID with root OWID ' +
+        'passes', () => {
+        // The party signature covers the party bytes followed by the
+        // complete root OWID, so the root must be supplied to verify.
+        var party = new owid(f.chainParty);
+
+        return party.verify([f.chainRoot]).then(valid => {
+            expect(valid).toBe(true);
+        });
+    });
+
+    test('interop verify ' + f.language + ' party OWID without root OWID ' +
+        'fails', () => {
+        // Without the root OWID the signed message cannot be rebuilt, so
+        // verification must fail.
+        var party = new owid(f.chainParty);
+
+        return party.verify().then(valid => {
+            expect(valid).toBe(false);
+        });
+    });
+
+    test('interop verify ' + f.language + ' tampered OWID fails', () => {
+        // Corrupt the last byte, which is always within the 64 byte
+        // signature.
+        var o = new owid(corruptByte(f.simple, -1));
+
+        return o.verify().then(valid => {
+            expect(valid).toBe(false);
+        });
+    });
+});

--- a/owid.test.js
+++ b/owid.test.js
@@ -42,36 +42,44 @@ const testBadOWID =
     "gw36t85HLwL6YdV4i9kYDCdsP54RS8on/roKKASyh19TpcUQxkIRALFk";
 
 beforeEach(() => {
-    // fetchMock.doMock();
+    fetchMock.resetMocks();
 
-    // fetchMock.dontMock();
-
-    fetchMock.mockResponse(req => {
+    fetchMock.mockResponse(async req => {
         var urlString = req.url;
         if (urlString.startsWith("//")) {
             urlString = "http:" + urlString;
+        } else if (urlString.startsWith("/")) {
+            urlString = "http://localhost" + urlString;
         }
         var url = new URL(urlString);
 
         if (url.pathname.endsWith("/verify")) {
-            if (url.searchParams.get('owid') == testBadOWID) {
-                return Promise.resolve(JSON.stringify({valid: false}));
-            } else if (url.searchParams.get('owid') == null || url.searchParams.get('owid') == "") {
-                return Promise.resolve({
+            // The library sends the OWID being verified as form parameters
+            // in the POST body, so read them from there.
+            var body = new URLSearchParams(await req.text());
+            var owidParam = body.get("owid");
+            if (owidParam == testBadOWID) {
+                return JSON.stringify({valid: false});
+            } else if (owidParam == null || owidParam == "") {
+                return {
                     status: 400,
                     body: "Not Found"
-                  });
+                };
             } else {
-                return Promise.resolve(JSON.stringify({valid: true}));
+                return JSON.stringify({valid: true});
             }
+        } else if (url.pathname.endsWith("/stop")) {
+            // Respond with a fragment so that the redirect performed by the
+            // stop method is a hash change that jsdom can complete.
+            return "#stopped";
         } else {
-          return  Promise.resolve({
-            status: 404,
-            body: "Not Found"
-          });
+            return {
+                status: 404,
+                body: "Not Found"
+            };
         }
     });
-    
+
 });
 
 test('verify OWID', () => {
@@ -218,4 +226,123 @@ test ('verify empty string throws error', () => {
 
     expect(() => o.verify("")).toThrow();
     expect(() => o.verify("")).toThrow("OWID(s) must have a value and cannot be an empty string.");
+});
+
+// The date field of the creator fixture decodes to 664619 minutes after the
+// OWID base date of 2020-01-01 00:00, which is 2021-04-06 12:59. Note that
+// the implementation parses the base date without an explicit UTC marker, so
+// the result matches UTC only when the local time zone offset is zero on
+// 2020-01-01, as it is for the UK where these tests are normally run.
+test('dateAsJavaScriptDate returns the creation date to the minute', () => {
+    var o = new owid(testCreatorOWID);
+
+    expect(o.date).toBe(664619);
+    var expected = new Date(Date.UTC(2020, 0, 1) + 664619 * 60 * 1000);
+    expect(o.dateAsJavaScriptDate().getTime()).toBe(expected.getTime());
+    expect(o.dateAsJavaScriptDate().toISOString())
+        .toBe("2021-04-06T12:59:00.000Z");
+});
+
+test('constructor with invalid base 64 throws', () => {
+    expect(() => new owid("not valid base64!!!")).toThrow();
+});
+
+test('parse with invalid base 64 throws', () => {
+    var o = new owid();
+
+    expect(() => o.parse("not valid base64!!!")).toThrow();
+});
+
+// Truncating the fixture after the date field leaves valid base 64 that no
+// longer contains a payload or signature. The parser reads the fields that
+// are present and returns empty arrays for the rest rather than throwing.
+test('constructor with truncated base 64 parses available fields', () => {
+    var o = new owid(testCreatorOWID.substring(0, 20));
+
+    expect(o.domain).toBe("51db.uk");
+    expect(o.date).toBe(664619);
+    expect(o.owid.payload.length).toBe(0);
+    expect(o.signature.length).toBe(0);
+});
+
+test.each([
+    [42],
+    [{}],
+    [null],
+    [true],
+])('constructor with non-string input %p throws', (value) => {
+    expect(() => new owid(value))
+        .toThrow("'data' parameter must be a string or undefined");
+});
+
+// The expected values below were derived by parsing the fixture once and are
+// locked in here as a regression test.
+test('creator OWID fields decode to expected values', () => {
+    var o = new owid(testCreatorOWID);
+
+    expect(o.owid.version).toBe(2);
+    expect(o.domain).toBe("51db.uk");
+    expect(o.date).toBe(664619);
+    expect(o.owid.payload.length).toBe(341);
+    expect(o.signature.length).toBe(64);
+    expect(o.signature[0]).toBe(74);
+    expect(o.signature[63]).toBe(64);
+});
+
+// The expected values below were derived by parsing the fixture once and are
+// locked in here as a regression test. The party OWID has a two byte payload
+// of 0x01 0x03 which makes the exact value assertions easy to read.
+test('party OWID payload accessors return exact values', () => {
+    var o = new owid(testSupplierOWID);
+
+    expect(o.owid.version).toBe(2);
+    expect(o.domain).toBe("pop-up.swan-demo.uk");
+    expect(o.date).toBe(664619);
+    expect(o.payloadAsString()).toBe("\u0001\u0003");
+    // payloadAsPrintable does not pad single digit hex values, so the two
+    // payload bytes 0x01 and 0x03 print as "13".
+    expect(o.payloadAsPrintable()).toBe("13");
+    expect(o.payloadAsBase64()).toBe("AQM=");
+    expect(o.signature.length).toBe(64);
+});
+
+test('verify rejects when the verify end point returns an error', () => {
+    fetchMock.mockResponseOnce("Server Error", { status: 500 });
+    var o = new owid(testCreatorOWID);
+
+    return expect(o.verify())
+        .rejects.toMatch("'Verify' request HTTP status code: 500");
+});
+
+test('verify rejects when the verify end point cannot be reached', () => {
+    fetchMock.mockRejectOnce(new Error("Network failure"));
+    var o = new owid(testCreatorOWID);
+
+    return expect(o.verify()).rejects.toThrow("Network failure");
+});
+
+test('stop issues the expected POST to the stop end point', async () => {
+    var logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    try {
+        var o = new owid();
+
+        o.stop(undefined, "cmp.swan-demo.uk", "https://return.swan-demo.uk/");
+
+        expect(fetch.mock.calls.length).toBe(1);
+        var url = fetch.mock.calls[0][0];
+        var init = fetch.mock.calls[0][1];
+        expect(url).toBe("/stop");
+        expect(init.method).toBe("POST");
+        expect(init.body.get("host")).toBe("cmp.swan-demo.uk");
+        expect(init.body.get("returnUrl")).toBe("https://return.swan-demo.uk/");
+
+        // Allow the response chain inside stop to settle before the test
+        // ends. The mocked response is a fragment so the redirect becomes a
+        // hash change that jsdom supports.
+        await new Promise(resolve => setTimeout(resolve, 0));
+        await new Promise(resolve => setTimeout(resolve, 0));
+        expect(window.location.hash).toBe("#stopped");
+    } finally {
+        logSpy.mockRestore();
+    }
 });

--- a/v1.js
+++ b/v1.js
@@ -15,12 +15,15 @@
  * ***************************************************************************/
 
 /**
- * @class {owid} Open Web Id (OWID) library for client side parsing and 
- * verification of Open Web Ids.
+ * @class {owid} Open Web Id (OWID) library for client side parsing and
+ * verification of Open Web Ids. This library is verify only. Creation and
+ * signing of OWIDs is performed by the server side implementations owid-go
+ * and owid-dotnet.
  * @param {string} data             - base 64 encoded byte array
+ * @property {string} data          - The base 64 string the instance was created from.
  * @property {object} owid          - The OWID tree.
  * @property {string} domain        - Returns the creator of the OWID.
- * @property {int} date          - Returns the date and time the OWID was created in UTC.
+ * @property {int} date             - Returns the date and time the OWID was created as minutes since 2020-01-01 00:00.
  * @property {Uint8Array} signature - Returns the signature as byte array.
  */
 owid = function (data) {
@@ -361,8 +364,10 @@ owid = function (data) {
 
     /**
      * Returns the OWID creation date as a JavaScript Date object.
-     * @returns {Object} -  the OWID instance creation date as a JavaScript Date
-     * object.
+     * @function
+     * @memberof owid
+     * @returns {Date} the OWID instance creation date as a JavaScript Date
+     * object accurate to the minute.
      */
     this.dateAsJavaScriptDate = function() {
         var jsDate = new Date();
@@ -370,9 +375,13 @@ owid = function (data) {
         return jsDate;
     }
 
-    /** 
-     * Parses a base 64 encoded byte array into a OWID tree.
-     * @param {string} t - base 64 encoded byte array representing an OWID tree.
+    /**
+     * Parses a base 64 encoded byte array into a OWID tree. When no
+     * parameter is provided the data the instance was created from is used.
+     * @function
+     * @memberof owid
+     * @param {string} [t] - base 64 encoded byte array representing an OWID
+     * tree.
      * @returns {Object} OWID tree.
      */
     this.parse = function (t) {
@@ -397,9 +406,10 @@ owid = function (data) {
     }
 
     /**
-     * Returns the payload in hexadecimal.
+     * Returns the payload in hexadecimal. Single digit values are not
+     * padded with a leading zero.
      * @function
-     * @member owid
+     * @memberof owid
      * @returns {string} This OWID instance's payload as a hexadecimal.
      */
     this.payloadAsPrintable = function () {
@@ -417,10 +427,14 @@ owid = function (data) {
     }
 
     /**
-     * Stop an advert.
-     * @param {*} s - SWAN OWID
-     * @param {string} d - organization domain.
-     * @param {string} r - return url
+     * Stop an advert. Posts the organization domain and the return URL to
+     * the /stop end point and then redirects the browser to the URL
+     * contained in the response.
+     * @function
+     * @memberof owid
+     * @param {*} s - SWAN OWID, reserved and currently unused.
+     * @param {string} d - organization domain to stop.
+     * @param {string} r - return url to come back to once stopped.
      */
     this.stop = function (s, d, r) {
         var data = new URLSearchParams();


### PR DESCRIPTION
* Fixes the fetch mock so the baseline suite passes on Node 24. The mock read the owid parameter from the query string while the library sends it in the POST body, so every verify call returned 400.
* Adds real ECDSA verification tests using the web crypto implementation provided by Node 24.
* Adds cross-language interop tests verifying fixtures signed by the Rust, Go and .NET implementations, 57 tests in total.
* README restructured to the common template shared by the sibling repositories. Library changes are JSDoc only.