### PR TITLE
FEAT: request the public key for the OWID's own date when verifying

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,11 @@ public key from their well known end point and verifies the ECDSA signature
 locally. When `crypto.subtle` is not available it falls back to the creator's
 remote verify end point.
 
+The public key is requested for the OWID's own creation date
+(`?date=<minutes>`), so OWIDs signed before a signing-key rotation still
+verify. A creator that does not support the `date` parameter ignores it and
+returns its current key.
+
 ## Usage
 
 To use OWID-js:

--- a/owid.crypto.test.js
+++ b/owid.crypto.test.js
@@ -156,7 +156,7 @@ test('crypto verify valid OWID passes', () => {
         // request is to the creator end point.
         expect(fetch.mock.calls.length).toBe(1);
         expect(fetch.mock.calls[0][0]).toBe(
-            "//" + creatorDomain + "/owid/api/v1/creator");
+            "//" + creatorDomain + "/owid/api/v1/creator?date=" + testDateInMinutes);
     });
 });
 

--- a/owid.interop.test.js
+++ b/owid.interop.test.js
@@ -173,7 +173,7 @@ fixtures.forEach(f => {
             // request is to the creator end point.
             expect(fetch.mock.calls.length).toBe(1);
             expect(fetch.mock.calls[0][0]).toBe(
-                "//" + f.domain + "/owid/api/v1/creator");
+                "//" + f.domain + "/owid/api/v1/creator?date=" + o.date);
         });
     });
 

--- a/v1.js
+++ b/v1.js
@@ -326,6 +326,11 @@ owid = function (data) {
      */
     function verifyOWIDObjectWithPublicKey(r, o) {
         var url = "//" + o.domain + "/owid/api/v1/creator";
+        if (o.date != null) {
+            // Request the key that was current when this OWID was signed, so
+            // OWIDs created before a key rotation still verify.
+            url += "?date=" + o.date;
+        }
         return fetch(
             url,
             { mode: "cors", cache: "default" })


### PR DESCRIPTION
- When verifying an OWID, the public-key fetch now includes ?date=<minutes> taken from the OWID's own Date field, so identifiers signed before a signing-key rotation still verify against the key that was current then.
- A creator that does not support `date` ignores it and returns the current key.